### PR TITLE
Add draft profile schema 3.0 for METS 2

### DIFF
--- a/profile_docs/METS2_profile.xsd
+++ b/profile_docs/METS2_profile.xsd
@@ -1,67 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  METS Profile Schema Version 2.1 -->
-<!-- 
-This document is available under the Creative Commons CC0 1.0 Universal Public Domain Dedication 
-(http://creativecommons.org/publicdomain/zero/1.0/). The Digital Library Federation, as creator of 
-this document, has waived all rights to it worldwide under copyright law, including all related and
-neighboring rights, to the extent allowed by law. For the full text see 
-http://creativecommons.org/publicdomain/zero/1.0/legalcode.
--->
-<!-- Prepared for the Digital Library Federation by the METS Editorial Board-->
-<!--
-	The METS Profile schema defines a document format for creating profiles of
-	a class of METS documents.  METS Profiles are intended to allow an individual
-	or organization to specify limitations and restrictions on the creation of METS
-	instance documents in order to define a document class.  METS instance 
-	documents which abide by those limitations and restrictions are said to conform to the profile.
-	
-	METS profiles may serve a variety of purposes, but their primary purpose is
-	to promote interoperability and exchange of METS documents.  By allowing
-	any given institution to specify and publicize its practices with regards to creation
-	and use of METS documents, it can assist others both in creating METS
-	instances to be submitted to that institution and in processing METS documents
-	created by that institution.
-	
-	Version 2 of the METS schema extends the provisions of version 1.  In particular, it provides much 
-	more extensive support for formatting documentation by means of xhtml elements which can be
-	used in the context of the textSection data type.  In addition, as a first step towards machine actionability,
-	the schema provides a means of specifying tests that can be applied to verify that specified requirements
-	have been met.  Additional enhancements over the version 1 profile schema are described in the
-	schema documentation.
-	
-	Version 2.1 (April 2018) added the Creative Commons CC0 1.0 license.  This version also added the xml:lang 
-	attribute to more elements to make it easier to create multi-lingual profiles.  These elements were affected:
-	
-	* The external_schema/name element is now repeatable and allows the xml:lang attribute
-	* The external_schema/context element now allows the xml:lang attribute
-	* The controlled_vocabularies/vocabulary/name element is now repeatable and allows the xml:lang attribute
-	* The controlled_vocabularies/vocabulary/context element now allows the xml:lang attribute	
-	* The tool/name element is now repeatable and allows the xml:lang attribute	
-	* The textSection/head complextype now allows the xml:lang attribute
-
-  Version 3.0 (January 2024 - DRAFT) updates the profile schema for use with the
-  METS schema version 2.
-
-  Changes to align with linking and external references in METS 2:
-  * allows any values for LOCTYPE and provides a link to suggested values
-  * removes the OTHERLOCTYPE attribute.
-  * removes the XLink schema and the xlink attributes for the testRef element
-  * adds LOCREF and LOCTYPE attributes for the testRef element
-
-  Changes to align with METS 2 elements:
-  * replaces amdSec, dmdSec elements with mdSec
-  * replaces structMap element with structSec,
-  * removes structLink and behaviorSec elements
-  * removes behavior_files element
-	
-	Institutions wishing to make their profiles widely available may wish to consider
-	formally registering them through the METS Editorial Board with the Library of Congress.
-	Instructions on registering a profile may be found at the METS website (http://www.loc.gov/mets/).
-
--->
-<xsd:schema targetNamespace="http://www.loc.gov/METS_Profile/v3" xmlns="http://www.loc.gov/METS_Profile/v3" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <!-- TODO: Change to METS2_Profile/vNNN ? -->
+<xsd:schema targetNamespace="http://www.loc.gov/METS_Profile/vNNN" xmlns="http://www.loc.gov/METS_Profile/vNNN" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>	
 	<xsd:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation xml:lang="en">
+      METS 2 Profile Schema Version NNN
+
+      This document is available under the Creative Commons CC0 1.0 Universal Public Domain Dedication 
+      (http://creativecommons.org/publicdomain/zero/1.0/). The Digital Library Federation, as creator of 
+      this document, has waived all rights to it worldwide under copyright law, including all related and
+      neighboring rights, to the extent allowed by law. For the full text see 
+      http://creativecommons.org/publicdomain/zero/1.0/legalcode.
+
+      Prepared by the METS Editorial Board
+
+      Karin Bredenberg (Sydarkivera, Sweden)
+      Bertrand Caron (Bibliothèque nationale de France)
+      Aaron Elkiss (HathiTrust / University of Michigan)
+      Inge Hofsink (KB National Library of the Netherlands)
+      Juha Lehtonen (CSC – IT Center for Science, Finland)
+      Andreas Nef (Docuteam GmbH, Baden, Switzerland)
+      Tobias Steinke (German National Library)
+      Robin Wendler (Harvard University)
+
+      March, 2024
+      Version NNN
+    </xsd:documentation>
+    <xsd:documentation xml:lang="en">
+      The METS Profile schema defines a document format for creating profiles of
+      a class of METS documents.  METS Profiles are intended to allow an individual
+      or organization to specify limitations and restrictions on the creation of METS
+      instance documents in order to define a document class.  METS instance 
+      documents which abide by those limitations and restrictions are said to conform to the profile.
+      
+      METS profiles may serve a variety of purposes, but their primary purpose is
+      to promote interoperability and exchange of METS documents.  By allowing
+      any given institution to specify and publicize its practices with regards to creation
+      and use of METS documents, it can assist others both in creating METS
+      instances to be submitted to that institution and in processing METS documents
+      created by that institution.
+    </xsd:documentation>
+    <xsd:documentation xml:lang="en">
+      Change log
+
+      Version NNN (March 2024 - DRAFT) updates the profile schema for use with the
+      METS schema version 2.
+
+      Changes to align with linking and external references in METS 2:
+      * allows any values for LOCTYPE and provides a link to suggested values
+      * removes the OTHERLOCTYPE attribute.
+      * removes the XLink schema and the xlink attributes for the testRef element
+      * adds LOCREF and LOCTYPE attributes for the testRef element
+
+      Changes to align with METS 2 elements:
+      * replaces amdSec, dmdSec elements with mdSec
+      * replaces structMap element with structSec,
+      * removes structLink and behaviorSec elements
+      * removes behavior_files element
+      
+      Version 2.1 (April 2018) added the Creative Commons CC0 1.0 license.  This version also added the xml:lang 
+      attribute to more elements to make it easier to create multi-lingual profiles.  These elements were affected:
+      
+      * The external_schema/name element is now repeatable and allows the xml:lang attribute
+      * The external_schema/context element now allows the xml:lang attribute
+      * The controlled_vocabularies/vocabulary/name element is now repeatable and allows the xml:lang attribute
+      * The controlled_vocabularies/vocabulary/context element now allows the xml:lang attribute	
+      * The tool/name element is now repeatable and allows the xml:lang attribute	
+      * The textSection/head complextype now allows the xml:lang attribute
+
+      Version 2 of the METS profile schema extends the provisions of version 1.  In particular, it provides much 
+      more extensive support for formatting documentation by means of xhtml elements which can be
+      used in the context of the textSection data type.  In addition, as a first step towards machine actionability,
+      the schema provides a means of specifying tests that can be applied to verify that specified requirements
+      have been met.  Additional enhancements over the version 1 profile schema are described in the
+      schema documentation.
+    </xsd:documentation>
+    <xsd:documentation xml:lang="en">
+      Institutions wishing to make their profiles widely available may wish to consider
+      submitting them as public examples. Instructions for submitting a profile may be found
+      at https://github.com/METS/METS-profiles. This process replaces the formal registration
+      process used with earlier versions of METS profiles.
+    </xsd:documentation>
+  </xsd:annotation>
+  <!-- TODO: Should the root element change to METS2_Profile ? -->
 	<xsd:element name="METS_Profile">
 		<xsd:annotation>
 			<xsd:documentation xml:lang="en">Root element for a METS Profile</xsd:documentation>
@@ -70,7 +93,7 @@ http://creativecommons.org/publicdomain/zero/1.0/legalcode.
 			<xsd:sequence>
 				<xsd:element name="URI" maxOccurs="unbounded">
 					<xsd:annotation>
-						<xsd:documentation xml:lang="en">Every METS profile must be assigned a unique URI RFC 2396 by the institution responsible for its creation. This URI must have the attribute ASSIGNEDBY=&quot;local&quot;. If the profile is to be publicly registered at the Library of Congress Network and MARC Standards Office, the URI must not duplicate any URI assigned to any currently registered profile. A second URI element will be added if and when a profile is registered at the Library of Congress. This URI will have the attribute ASSIGNEDBY=&quot;metsboard&quot;. </xsd:documentation>
+						<xsd:documentation xml:lang="en">Every METS profile must be assigned a unique URI RFC 2396 by the institution responsible for its creation. This URI must have the attribute ASSIGNEDBY=&quot;local&quot;. </xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:simpleContent>
@@ -199,19 +222,9 @@ http://creativecommons.org/publicdomain/zero/1.0/legalcode.
 						<xsd:attribute name="ROLE" type="xsd:string" use="optional"/>
 					</xsd:complexType>
 				</xsd:element>
-				<xsd:element name="registration_info" minOccurs="0">
-					<xsd:annotation>
-						<xsd:documentation xml:lang="en">A date when the profile was registered with the Library of Congress, and a URI for obtaining the registered profile from the Library (this will be provided by the registrars and need not be included in profiles being submitted); .</xsd:documentation>
-					</xsd:annotation>
-					<xsd:complexType>
-						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
-						<xsd:attribute name="regDate" type="xsd:dateTime" use="required"/>
-						<xsd:attribute name="regURI" type="xsd:anyURI" use="required"/>
-					</xsd:complexType>
-				</xsd:element>
 				<xsd:element name="related_profile" maxOccurs="unbounded">
 					<xsd:annotation>
-						<xsd:documentation xml:lang="en">A profile may indicate its relationship with other METS profiles. METS profiles are not explicitly versioned, as implementations may exist that use older editions of METS profiles. Therefore a new version of a profile must be registered as a new profile. In this case, the RELATIONSHIP attribute should be used to indicate that a profile supersedes a profile already registered with the Library of Congress Network Development and MARC Standards Office. For each related profile, the profile should specify a URI for the related profile and the nature of the relationship between the current profile and the related profile.</xsd:documentation>
+						<xsd:documentation xml:lang="en">A profile may indicate its relationship with other METS profiles. METS profiles are not explicitly versioned, as implementations may exist that use older editions of METS profiles. For each related profile, the profile should specify a URI for the related profile and the nature of the relationship between the current profile and the related profile.</xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType> 
 						<xsd:simpleContent>
@@ -268,7 +281,7 @@ extends -- profile builds on and extends an existing profile
 				</xsd:element>
 				<xsd:element name="external_schema" maxOccurs="unbounded">
 					<xsd:annotation>
-						<xsd:documentation xml:lang="en">A profile which will be registered with the Network Development and MARC Standards Office must identify all external schema which may be used in constructing a METS document conforming with the profile. external schema for registered profiles MUST be publicly available. The schema must be identified in sufficient detail to allow a document author previously unfamiliar with the schema to unambiguously identify and retrieve it. Those registering profiles with the Network Development and MARC Standards Office are strongly encouraged to include a URI for each identified external schema which may be used to retrieve that schema from any Internet workstation, and may wish to include the complete text of any required external schema as an appendix to their profile.  A single external_schema element should used for each external schema listed in the profile. Multiple external_schema elements may be used within a single profile. For each external schema described, you may provide a name of the schema, a URI assigned to the schema, a context description indicating where in a conforming METS document the schema may be used, and an additional note. The note element has an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.
+						<xsd:documentation xml:lang="en">A single external_schema element should used for each external schema listed in the profile. Multiple external_schema elements may be used within a single profile. For each external schema described, you may provide a name of the schema, a URI assigned to the schema, a context description indicating where in a conforming METS document the schema may be used, and an additional note. The note element has an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.
 						</xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
@@ -622,14 +635,6 @@ The Example element has two attributes:
 					</xsd:restriction>
 				</xsd:simpleType>
 			</xsd:attribute>
-			<xsd:attribute name="REGISTRATION" use="required">
-				<xsd:simpleType>
-					<xsd:restriction base="xsd:string">
-						<xsd:enumeration value="registered"/>
-						<xsd:enumeration value="unregistered"/>
-					</xsd:restriction>
-				</xsd:simpleType>				
-			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 	
@@ -723,18 +728,21 @@ The requirement element has two children: description and tests. The required de
 		</xsd:sequence>
 	</xsd:complexType>
 	
-	<!-- only the following group of HTML elements are allowed:
-		Paragraphs: <p>
-		All list elements: <ul>,<ol>,<dl>
-		Preformatted text: <pre>
-		Table: <table>
-		Image: <img>
-	-->
 	<xsd:group name="xhtmlelements">
 		<xsd:choice>
 			<xsd:element ref="xhtml:p"/>
 			<xsd:group ref="xhtml:lists"/>
 		</xsd:choice>	
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        only the following group of HTML elements are allowed:
+          Paragraphs: &lt;p&gt;
+          All list elements: &lt;ul&gt;,&lt;ol&gt;,&lt;dl&gt;
+          Preformatted text: &lt;pre&gt;
+          Table: &lt;table&gt;
+          Image: &lt;img&gt;
+      </xsd:documentation>
+    </xsd:annotation>
 	</xsd:group>
 	
 	

--- a/profile_docs/METS2_profile.xsd
+++ b/profile_docs/METS2_profile.xsd
@@ -729,20 +729,20 @@ The requirement element has two children: description and tests. The required de
 	</xsd:complexType>
 	
 	<xsd:group name="xhtmlelements">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">
+				only the following group of HTML elements are allowed:
+				Paragraphs: &lt;p&gt;
+				All list elements: &lt;ul&gt;,&lt;ol&gt;,&lt;dl&gt;
+				Preformatted text: &lt;pre&gt;
+				Table: &lt;table&gt;
+				Image: &lt;img&gt;
+			</xsd:documentation>
+		</xsd:annotation>
 		<xsd:choice>
 			<xsd:element ref="xhtml:p"/>
 			<xsd:group ref="xhtml:lists"/>
 		</xsd:choice>	
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
-        only the following group of HTML elements are allowed:
-          Paragraphs: &lt;p&gt;
-          All list elements: &lt;ul&gt;,&lt;ol&gt;,&lt;dl&gt;
-          Preformatted text: &lt;pre&gt;
-          Table: &lt;table&gt;
-          Image: &lt;img&gt;
-      </xsd:documentation>
-    </xsd:annotation>
 	</xsd:group>
 	
 	

--- a/profile_docs/METS2_profile.xsd
+++ b/profile_docs/METS2_profile.xsd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
   <!-- TODO: Change to METS2_Profile/vNNN ? -->
-<xsd:schema targetNamespace="http://www.loc.gov/METS_Profile/vNNN" xmlns="http://www.loc.gov/METS_Profile/vNNN" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xsd:schema targetNamespace="http://www.loc.gov/METS2_Profile" xmlns="http://www.loc.gov/METS2_Profile" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>	
 	<xsd:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd"/>
 
   <xsd:annotation>
     <xsd:documentation xml:lang="en">
-      METS 2 Profile Schema Version NNN
+      METS 2 Profile Schema (Draft, March 2024)
 
       This document is available under the Creative Commons CC0 1.0 Universal Public Domain Dedication 
       (http://creativecommons.org/publicdomain/zero/1.0/). The Digital Library Federation, as creator of 
@@ -25,11 +25,10 @@
       Tobias Steinke (German National Library)
       Robin Wendler (Harvard University)
 
-      March, 2024
-      Version NNN
+      DRAFT March, 2024
     </xsd:documentation>
     <xsd:documentation xml:lang="en">
-      The METS Profile schema defines a document format for creating profiles of
+      The METS 2 Profile schema defines a document format for creating profiles of
       a class of METS documents.  METS Profiles are intended to allow an individual
       or organization to specify limitations and restrictions on the creation of METS
       instance documents in order to define a document class.  METS instance 
@@ -45,8 +44,12 @@
     <xsd:documentation xml:lang="en">
       Change log
 
-      Version NNN (March 2024 - DRAFT) updates the profile schema for use with the
-      METS schema version 2.
+      March 2024 - DRAFT is a schema for use with METS 2, based on the the METS
+      Profile Schema
+      version 2.1
+      (https://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-1.xsd)
+
+      Changes from the METS Profile Schema version 2.1:
 
       Changes to align with linking and external references in METS 2:
       * allows any values for LOCTYPE and provides a link to suggested values
@@ -60,22 +63,7 @@
       * removes structLink and behaviorSec elements
       * removes behavior_files element
       
-      Version 2.1 (April 2018) added the Creative Commons CC0 1.0 license.  This version also added the xml:lang 
-      attribute to more elements to make it easier to create multi-lingual profiles.  These elements were affected:
-      
-      * The external_schema/name element is now repeatable and allows the xml:lang attribute
-      * The external_schema/context element now allows the xml:lang attribute
-      * The controlled_vocabularies/vocabulary/name element is now repeatable and allows the xml:lang attribute
-      * The controlled_vocabularies/vocabulary/context element now allows the xml:lang attribute	
-      * The tool/name element is now repeatable and allows the xml:lang attribute	
-      * The textSection/head complextype now allows the xml:lang attribute
-
-      Version 2 of the METS profile schema extends the provisions of version 1.  In particular, it provides much 
-      more extensive support for formatting documentation by means of xhtml elements which can be
-      used in the context of the textSection data type.  In addition, as a first step towards machine actionability,
-      the schema provides a means of specifying tests that can be applied to verify that specified requirements
-      have been met.  Additional enhancements over the version 1 profile schema are described in the
-      schema documentation.
+      For changes prior to METS 2, refer to https://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-1.xsd
     </xsd:documentation>
     <xsd:documentation xml:lang="en">
       Institutions wishing to make their profiles widely available may wish to consider
@@ -85,15 +73,15 @@
     </xsd:documentation>
   </xsd:annotation>
   <!-- TODO: Should the root element change to METS2_Profile ? -->
-	<xsd:element name="METS_Profile">
+	<xsd:element name="METS2_Profile">
 		<xsd:annotation>
-			<xsd:documentation xml:lang="en">Root element for a METS Profile</xsd:documentation>
+			<xsd:documentation xml:lang="en">Root element for a METS 2 Profile</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
 				<xsd:element name="URI" maxOccurs="unbounded">
 					<xsd:annotation>
-						<xsd:documentation xml:lang="en">Every METS profile must be assigned a unique URI RFC 2396 by the institution responsible for its creation. This URI must have the attribute ASSIGNEDBY=&quot;local&quot;. </xsd:documentation>
+						<xsd:documentation xml:lang="en">Every METS 2 profile must be assigned a unique URI RFC 2396 by the institution responsible for its creation. This URI must have the attribute ASSIGNEDBY=&quot;local&quot;. </xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:simpleContent>
@@ -614,7 +602,7 @@ The Example element has two attributes:
 				</xsd:element>		
 				<xsd:element name="Appendix" maxOccurs="unbounded">
 					<xsd:annotation>
-						<xsd:documentation xml:lang="en">A profile must contain an appendix containing an example METS document which conforms to the requirements set out in the profile. Profile authors should note that in order to insure that the completed profile document is valid, any namespace and schemaLocation declarations contained in the root &lt;mets&gt; element should be moved to the root &lt;METS_Profile&gt; element.</xsd:documentation>
+						<xsd:documentation xml:lang="en">A profile must contain an appendix containing an example METS document which conforms to the requirements set out in the profile. Profile authors should note that in order to insure that the completed profile document is valid, any namespace and schemaLocation declarations contained in the root &lt;mets&gt; element should be moved to the root &lt;METS2_Profile&gt; element.</xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:sequence>

--- a/profile_docs/mets.profile.v3-0.xsd
+++ b/profile_docs/mets.profile.v3-0.xsd
@@ -1,0 +1,854 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  METS Profile Schema Version 2.1 -->
+<!-- 
+This document is available under the Creative Commons CC0 1.0 Universal Public Domain Dedication 
+(http://creativecommons.org/publicdomain/zero/1.0/). The Digital Library Federation, as creator of 
+this document, has waived all rights to it worldwide under copyright law, including all related and
+neighboring rights, to the extent allowed by law. For the full text see 
+http://creativecommons.org/publicdomain/zero/1.0/legalcode.
+-->
+<!-- Prepared for the Digital Library Federation by the METS Editorial Board-->
+<!--
+	The METS Profile schema defines a document format for creating profiles of
+	a class of METS documents.  METS Profiles are intended to allow an individual
+	or organization to specify limitations and restrictions on the creation of METS
+	instance documents in order to define a document class.  METS instance 
+	documents which abide by those limitations and restrictions are said to conform to the profile.
+	
+	METS profiles may serve a variety of purposes, but their primary purpose is
+	to promote interoperability and exchange of METS documents.  By allowing
+	any given institution to specify and publicize its practices with regards to creation
+	and use of METS documents, it can assist others both in creating METS
+	instances to be submitted to that institution and in processing METS documents
+	created by that institution.
+	
+	Version 2 of the METS schema extends the provisions of version 1.  In particular, it provides much 
+	more extensive support for formatting documentation by means of xhtml elements which can be
+	used in the context of the textSection data type.  In addition, as a first step towards machine actionability,
+	the schema provides a means of specifying tests that can be applied to verify that specified requirements
+	have been met.  Additional enhancements over the version 1 profile schema are described in the
+	schema documentation.
+	
+	Version 2.1 (April 2018) added the Creative Commons CC0 1.0 license.  This version also added the xml:lang 
+	attribute to more elements to make it easier to create multi-lingual profiles.  These elements were affected:
+	
+	* The external_schema/name element is now repeatable and allows the xml:lang attribute
+	* The external_schema/context element now allows the xml:lang attribute
+	* The controlled_vocabularies/vocabulary/name element is now repeatable and allows the xml:lang attribute
+	* The controlled_vocabularies/vocabulary/context element now allows the xml:lang attribute	
+	* The tool/name element is now repeatable and allows the xml:lang attribute	
+	* The textSection/head complextype now allows the xml:lang attribute
+
+  Version 3.0 (January 2024 - DRAFT) updates the profile schema for use with the
+  METS schema version 2.
+
+  Changes to align with linking and external references in METS 2:
+  * allows any values for LOCTYPE and provides a link to suggested values
+  * removes the OTHERLOCTYPE attribute.
+  * removes the XLink schema and the xlink attributes for the testRef element
+  * adds LOCREF and LOCTYPE attributes for the testRef element
+
+  Changes to align with METS 2 elements:
+  * replaces amdSec, dmdSec elements with mdSec
+  * replaces structMap element with structSec,
+  * removes structLink and behaviorSec elements
+  * removes behavior_files element
+	
+	Institutions wishing to make their profiles widely available may wish to consider
+	formally registering them through the METS Editorial Board with the Library of Congress.
+	Instructions on registering a profile may be found at the METS website (http://www.loc.gov/mets/).
+
+-->
+<xsd:schema targetNamespace="http://www.loc.gov/METS_Profile/v3" xmlns="http://www.loc.gov/METS_Profile/v3" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>	
+	<xsd:import namespace="http://www.w3.org/1999/xhtml" schemaLocation="http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd"/>
+	<xsd:element name="METS_Profile">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">Root element for a METS Profile</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="URI" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">Every METS profile must be assigned a unique URI RFC 2396 by the institution responsible for its creation. This URI must have the attribute ASSIGNEDBY=&quot;local&quot;. If the profile is to be publicly registered at the Library of Congress Network and MARC Standards Office, the URI must not duplicate any URI assigned to any currently registered profile. A second URI element will be added if and when a profile is registered at the Library of Congress. This URI will have the attribute ASSIGNEDBY=&quot;metsboard&quot;. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:simpleContent>
+							<xsd:extension base="xsd:anyURI">
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+								<xsd:attribute name="LOCTYPE" type="xsd:string" use="required"/>
+								<xsd:attribute name="ASSIGNEDBY" use="required">
+									<xsd:simpleType>
+										<xsd:restriction base="xsd:string">
+											<xsd:enumeration value="metsboard"/>
+											<xsd:enumeration value="local"/>											
+										</xsd:restriction>
+									</xsd:simpleType>
+								</xsd:attribute>
+								<xsd:attribute name="REGDATE" type="xsd:date" use="optional"/>
+							</xsd:extension>
+						</xsd:simpleContent>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="title" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">The profile must contain a short, human readable string describing the class of METS objects being profiled (e.g., &quot;NYU Monograph&quot;, &quot;Stereographic Image&quot;, &quot;SCORM object&quot;, etc.). This title must not exceed 256 characters. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:simpleContent>
+							<xsd:extension base="medString">
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+								<xsd:attribute ref="xml:lang" use="optional"/>
+							</xsd:extension>
+						</xsd:simpleContent>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="abstract" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">The profile must contain a one-paragraph description of the profile's nature and purpose. This abstract must not exceed 2048 characters in length.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:simpleContent>
+							<xsd:extension base="longString">
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+								<xsd:attribute ref="xml:lang" use="optional"/>							
+							</xsd:extension>
+						</xsd:simpleContent>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="date">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">The profile must include the date and time the profile was created by the responsible institution.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:simpleContent>
+							<xsd:extension base="xsd:dateTime">
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+							</xsd:extension>
+						</xsd:simpleContent>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="contact" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">The profile must contain contact information for an individual or entity responsible for the profile's creation and who may be contacted for clarification of the contents of the profile. Contact information must include a mailing address that can be used to contact someone regarding the profile, and may also include the name of a specific individual to contact for information regarding the profile, the name of the institution responsible for creating the schema, a phone number for a contact individual and an e-mail address.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="name" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">The name of an individual who may be contacted regarding the profile.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="institution" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">The name of an institution which may be contacted regarding the profile.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="address">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en" >The address for the individual and/or institution which may be contacted regarding the profile.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="phone" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">A phone number which people may call for information regarding the profile. </xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="email" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">An e-mail address which people may contact for information regarding the profile.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+						<xsd:attribute name="ROLE" type="xsd:string" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="registration_info" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A date when the profile was registered with the Library of Congress, and a URI for obtaining the registered profile from the Library (this will be provided by the registrars and need not be included in profiles being submitted); .</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+						<xsd:attribute name="regDate" type="xsd:dateTime" use="required"/>
+						<xsd:attribute name="regURI" type="xsd:anyURI" use="required"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="related_profile" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A profile may indicate its relationship with other METS profiles. METS profiles are not explicitly versioned, as implementations may exist that use older editions of METS profiles. Therefore a new version of a profile must be registered as a new profile. In this case, the RELATIONSHIP attribute should be used to indicate that a profile supersedes a profile already registered with the Library of Congress Network Development and MARC Standards Office. For each related profile, the profile should specify a URI for the related profile and the nature of the relationship between the current profile and the related profile.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType> 
+						<xsd:simpleContent>
+							<xsd:extension base="xsd:string">
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+								<xsd:attribute name="URI" type="xsd:anyURI" use="optional"/>
+								<xsd:attribute name="RELATIONSHIP" type="xsd:string" use="optional">
+									<xsd:annotation>
+										<xsd:documentation xml:lang="en">While this attribute is optional, and no controlled vocabulary is prescribed for it, the following vocabulary is recommended for common relationships:
+supersedes -- profile is a new, revised version of an existing profile
+extends -- profile builds on and extends an existing profile
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:attribute>
+							</xsd:extension>								
+						</xsd:simpleContent>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="profile_context">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A profile may document the context in which it operates through the inclusion of a Resource Model and statement of Use Cases. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="resource_model" minOccurs="0" type="textSection">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">This section is made up of simple text describing what the objects are that the Profile deals with, and could include information such as whether the profile is intended for an OAIS SIP, AIP, or DIP. Available are an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="uses" minOccurs="0" maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">This section is made up of one uses element containing one or more use subelements, each describing a single use case. It is primarily envisioned to describe different requirements for METS documents at different points in their project lifecycle with a single profile, connecting a processing action with a specific feature of a METS document. The use element has an optional REQID attribute, which is an IDREF to the ID of a specific &lt;requirement&gt; element declared in the same profile.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:sequence>
+										<xsd:element name="use" maxOccurs="unbounded">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">The use element has an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img. The latter could be used to embed within the profile documentation such as a diagram of a business process that uses a METS document conforming to the profile.</xsd:documentation>
+											</xsd:annotation>
+											<xsd:complexType>
+												<xsd:complexContent>
+													<xsd:extension base="textSection">
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+														<xsd:attribute name="REQID" type="xsd:IDREFS" use="optional"/>
+													</xsd:extension>
+												</xsd:complexContent>												
+											</xsd:complexType>											
+										</xsd:element>
+									</xsd:sequence>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="external_schema" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A profile which will be registered with the Network Development and MARC Standards Office must identify all external schema which may be used in constructing a METS document conforming with the profile. external schema for registered profiles MUST be publicly available. The schema must be identified in sufficient detail to allow a document author previously unfamiliar with the schema to unambiguously identify and retrieve it. Those registering profiles with the Network Development and MARC Standards Office are strongly encouraged to include a URI for each identified external schema which may be used to retrieve that schema from any Internet workstation, and may wish to include the complete text of any required external schema as an appendix to their profile.  A single external_schema element should used for each external schema listed in the profile. Multiple external_schema elements may be used within a single profile. For each external schema described, you may provide a name of the schema, a URI assigned to the schema, a context description indicating where in a conforming METS document the schema may be used, and an additional note. The note element has an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="name" minOccurs="0" maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">The external schema name may be repeated if it is available in different languages; use the xml:lang attribute to differentiate.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+											<xsd:attribute ref="xml:lang" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="URL" minOccurs="0" maxOccurs="unbounded">
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:anyURI">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+											<xsd:attribute name="TARGETNAMESPACE" type="xsd:anyURI" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="context" minOccurs="0" maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">The external schema context may be repeated.  Use the xml:lang attribute to indicate contexts provided in different languages.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+											<xsd:attribute ref="xml:lang" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="note" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="textSection">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>									
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="description_rules">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">An institution may choose to employ particular rules of description when encoding text within elements and attributes of a METS document. For example, a library might decide that descriptive metadata within a &lt;dmdSec&gt;&lt;mdWrap&gt; section will be encoded using the Library of Congress&apos; MARC 21 XML Schema MARCXML, and that the content of all elements and attributes within the MARC 21 XML sections must be prepared in accordance with the Anglo-American Cataloguing Rules 2nd Edition AACR2. The Rules of Description portion of a METS profile for that institution&apos;s METS objects should indicate that AACR2 must be applied to all content within a MARC 21 XML Schema portion of a METS document conforming to that profile. The description_rules element has an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:complexContent>
+							<xsd:extension base="textSection">
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+							</xsd:extension>
+						</xsd:complexContent>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="controlled_vocabularies">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">An institution may choose to employ certain controlled vocabularies, such as the Library of Congress Subject Headings or the Getty Thesaurus of Geographic Names, for the content of elements within portions of a METS document. If use of a particular controlled vocabulary is mandatory in any section of a conforming METS document, that controlled vocabulary must be listed in this section of a profile. For all such controlled vocabularies, you should provide a name for the controlled vocabulary, an agency responsible for the vocabulary's maintenance, and a URI assigned to the vocabulary. If you desire, you may also include the individual values/terms within the controlled vocabulary, although it is anticipated that this will only be done when you wish to publicize the contents of a locally-produced controlled vocabulary to others who wish to produce conforming METS documents; there is no need to itemize the contents of well-known controlled vocabularies such as LCSH. For all controlled vocabularies, you should provide contextual information indicating where within a conforming METS document the vocabulary may be used, and if desired brief description of the vocabulary and its purpose. The context and description subelements of vocabulary have an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="vocabulary" minOccurs="0" maxOccurs="unbounded">
+								<xsd:complexType>
+									<xsd:sequence>
+										<xsd:element name="name" minOccurs="0" maxOccurs="unbounded">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">The vocabulary name may be repeated if there are multiple versions of the name in different languages; use the xml:lang attribute to differentiate them.</xsd:documentation>
+											</xsd:annotation>
+											<xsd:complexType>
+												<xsd:simpleContent>
+													<xsd:extension base="xsd:string">
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+														<xsd:attribute ref="xml:lang" use="optional"/>
+													</xsd:extension>
+												</xsd:simpleContent>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="maintenance_agency" minOccurs="0">
+											<xsd:complexType>
+												<xsd:simpleContent>
+													<xsd:extension base="xsd:string">
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+													</xsd:extension>
+												</xsd:simpleContent>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="URI" minOccurs="0">
+											<xsd:complexType>
+												<xsd:simpleContent>
+													<xsd:extension base="xsd:anyURI">
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+													</xsd:extension>
+												</xsd:simpleContent>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="values" minOccurs="0">
+											<xsd:complexType>
+												<xsd:sequence>
+													<xsd:element name="value" maxOccurs="unbounded">
+														<xsd:complexType>
+															<xsd:simpleContent>
+																<xsd:extension base="xsd:string">
+																	<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+																</xsd:extension>
+															</xsd:simpleContent>
+														</xsd:complexType>
+													</xsd:element>
+												</xsd:sequence>
+												<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="context" minOccurs="0" maxOccurs="unbounded">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">The vocabulary context may be repeated if there are multiple versions of the context in different languages; use the xml:lang attribute to differentiate them.</xsd:documentation>
+											</xsd:annotation>
+											<xsd:complexType>
+												<xsd:simpleContent>
+													<xsd:extension base="xsd:string">
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+														<xsd:attribute ref="xml:lang" use="optional"/>
+													</xsd:extension>
+												</xsd:simpleContent>
+											</xsd:complexType>
+										</xsd:element>
+										<xsd:element name="description" minOccurs="0">
+											<xsd:complexType>
+												<xsd:complexContent>
+													<xsd:extension base="textSection">
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+													</xsd:extension>
+												</xsd:complexContent>
+											</xsd:complexType>
+										</xsd:element>
+									</xsd:sequence>
+									<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="structural_requirements">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">The METS document structure is extraordinarily flexible; that flexibility may be problematic inasmuch as creating software to process any arbitrary METS document in any but the most rudimentary way (XML parsing and validation) is a non-trivial task. This task can be simplified to some degree if those creating software to process METS documents know that there are further constraints on the structure of a METS document beyond those of the METS schema itself. The structural requirements portion of a METS profile allows an institution to delineate additional restrictions on the structure of a conforming METS document beyond those specified by the METS format itself. It is permissible to specify restrictions on the structure of a conforming METS document which cannot be validated by standard XML validation tools. For example, it would be a permissible restriction to state that master still images within a METS document should be contained within a separate file group from derivative images. It is impossible to fully delineate the possible additional structural restrictions that institutions may wish to set forth in their profiles, but the following list identifies some major areas of concern that institutions may wish to address in the Structural Requirements portion of a profile: 
+--Are there any restrictions on the number of occurrences of elements or attributes set forth in the METS schema beyond those specified by the METS schema itself (e.g., there should only be one occurrence of a dmdSec, every conforming document must include a metsHdr element, etc.)? 
+--Are there any restrictions on the number of occurrences of elements or attributes encoded using extension schema beyond those specified by those schema? 
+--May extension schema only be used within a particular portion of a METS document (e.g., you may wish to specify that a particular extension schema may be used within a &lt;mdWrap&gt; element within a &lt;techMD&gt; section, but that it should not be used within a &lt;sourceMD&gt; section). 
+--Should the structural map conform to a particular model? For instance, a profile for monographs might specify that the root &lt;div&gt; element must have a TYPE attribute of &quot;book&quot;, that all immediately subsidiary &lt;div&gt;s have a TYPE attribute of &quot;chapter&quot;. Alternatively, it might specify that there be a root &lt;div&gt; with a TYPE attribute of "text" with subsidiary &lt;div&gt;s having a TYPE attribute of &quot;page&quot;. Structural metadata is the heart of a METS document, and those creating profiles should try to be as explicit and precise as possible in specifying how structural maps should be created, and may wish to include examples within an appendix to the profile. 
+--Should document authors include metadata within a METS document using mdWrap, or reference it using mdRef? Or are both allowable? 
+--Should content files be included within a METS document using Fcontent, or referenced using FLocat? Or are both allowable?
+The structural_requirements is subdivided into subelements for each major section of a METS document. Requirements pertaining to a particular section should be listed underneath the section of the METS document to which they pertain. If you need to specify a structural requirement that involves more than one major section of the METS document, list it underneath the multiSection subelement within the structural_requirements element. Every subelement within the structural_requirements section is composed
+of a sequence of individual requirement elements.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="metsRootElement" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="metsHdr" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="mdSec" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="fileSec" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="structSec" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="multiSection" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="technical_requirements">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A METS document may reference a variety of external files, including the content files for the METS object (via &lt;FLocat&gt;elements), executable behaviors (via the &lt;mechanism&gt; element), and external metadata files (via &lt;mdRef&gt; elements). Non-XML content and metadata files may also be embedded within a METS instance, if they have been Base64 encoded. Institutions may wish to place restrictions on the nature of these external and non-XML files, such as insisting that all image files be in the TIFF 6.0 format and have a bit-depth between 16 and 32 bits, or that references to external metadata identified as being of type &quot;MARC&quot; via the MDTYPE attribute will point to MARC records conforming to the MARC 21 standard (or alternatively, to an HTML display of a MARC 21 record). 
+The Technical Requirements section of a profile allows institutions to set forth the full set of restrictions on the technical nature of files which may be referenced from a conforming METS document. It is subdivided into sections for restrictions on content files, restrictions on behavior files, and restrictions on metadata files. Profile authors should bear in mind that one of the primary purposes of the Technical Requirements section is to allow software developers to anticipate what types of content will be accessible via links from the METS objects, and hence what software is needed to process that content. 
+Every subelement within the technical_requirements section is composed of a sequence of individual requirement elements.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="content_files" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>	
+							<xsd:element name="metadata_files" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="reqs">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="tool" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A profile should provide a description of any affiliated tools, including validators, stylesheets, authoring tools, rendering applications, which can or should be used with METS documents conforming to the profile. The description should provide a name for the tool, the agency responsible for its development, a description of the tool, and a URI for obtaining the tool or further information regarding it. The description and note subelments of tool have an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="name" minOccurs="0" maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">The tool name may be repeated if there are multiple versions of the name in different languages; use the xml:lang attribute to differentiate them.</xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+											<xsd:attribute ref="xml:lang" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="agency" minOccurs="0">
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:string">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="URI" minOccurs="0" maxOccurs="unbounded">
+								<xsd:complexType>
+									<xsd:simpleContent>
+										<xsd:extension base="xsd:anyURI">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:simpleContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="description" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="textSection">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="note" minOccurs="0">
+								<xsd:complexType>
+									<xsd:complexContent>
+										<xsd:extension base="textSection">
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:extension>
+									</xsd:complexContent>
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="Example" minOccurs="0" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A METS profile may contain one or more Example elements.  Unlike Appendix elements, which are expected to contain complete METS encodings, an Example element would contain just a code snippet intended to demonstrate some requirement of the profile. The data type of the Examples element allows for partial, well-formed encodings that still might not satisfy all of the requirements for a full METS encoding.  
+A requirement can link to one or more Example elements by referencing the ID value of the pertinent Example elements in its EXAMPLES attribute. 
+The Example element has two attributes: 
+1.	ID.  This attribute is required, as every Example should be linked to from the requirement of which it is an example.  
+2.	LABEL.  This optional attribute allows for the descriptive labeling of an example.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:any namespace="##any" maxOccurs="unbounded" processContents="skip"/>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="required"/>
+						<xsd:attribute name="LABEL" type="xsd:string" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>		
+				<xsd:element name="Appendix" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation xml:lang="en">A profile must contain an appendix containing an example METS document which conforms to the requirements set out in the profile. Profile authors should note that in order to insure that the completed profile document is valid, any namespace and schemaLocation declarations contained in the root &lt;mets&gt; element should be moved to the root &lt;METS_Profile&gt; element.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:any namespace="##any" maxOccurs="unbounded"/>
+						</xsd:sequence>
+						<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+						<xsd:attribute name="NUMBER" type="xsd:integer" use="required"/>
+					    <xsd:attribute name="LABEL" type="xsd:string" use="optional"/>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+			<xsd:attribute name="STATUS" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="final"/>
+						<xsd:enumeration value="provisional"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="REGISTRATION" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="registered"/>
+						<xsd:enumeration value="unregistered"/>
+					</xsd:restriction>
+				</xsd:simpleType>				
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:complexType name="textSection">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">Complex type for elements with extensive textual material</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+		    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+		        <xsd:element name="head" minOccurs="0" maxOccurs="1">
+		        	<xsd:annotation>
+		        		<xsd:documentation xml:lang="en">The section head may be repeated.  If there are multiple versions of the head in different languages; use the xml:lang attribute to differentiate them.</xsd:documentation>
+		        	</xsd:annotation>
+		        	<xsd:complexType>
+					    <xsd:simpleContent>
+						    <xsd:extension base="xsd:string">
+							    <xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+						    	<xsd:attribute ref="xml:lang" use="optional"/>
+    						</xsd:extension>
+	    				</xsd:simpleContent>
+		    		</xsd:complexType>
+		        </xsd:element>
+		    	<xsd:group ref="xhtmlelements"/>
+		    </xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+	<xsd:complexType name="reqs">
+		<xsd:sequence>
+			<xsd:element name="requirement" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">The requirement element has four attributes:
+1.	an optional XML ID attribute, 
+2.	an optional IDREFS attribute called RELATEDMAT, which you may use to indicate other portions of the profile document where this particular requirement is relevant.  Requirement elements are in turn composed of a sequence of paragraph &lt;p&gt; elements,
+3.	an optional IDREFS attribute called EXAMPLES, which you may use to point to examples in the &lt;Examples&gt; section that demonstrate the requirement, and
+4.	an optional REQLEVEL attribute with values drawn from RFC 2119 (http://www.ietf.org/rfc/rfc2119.txt) .
+-----MUST: This word means that the definition is an absolute requirement.
+-----SHOULD: This word means that there may exist valid reasons in particular circumstances to ignore the requirement, but the full implications must be understood and carefully weighed before choosing a different course.
+-----MUST NOT: This phrase means that the prohibition described in the requirement is an absolute prohibition of the profile.
+-----SHOULD NOT: This phrase means that there may exist valid reasons in particular circumstances when violating the prohibition described in the requirement is acceptable or even useful, but the full implications should be understood and the case carefully weighed before doing so. The requirement text should clarify such circumstances.
+-----MAY: This word means that an item is not prohibited but fully optional.
+The requirement element has two children: description and tests. The required description element has an optional head subelement and some available text formatting elements from the xhtml namespace. Available xhtml elements include p, various list/item elements, text formatting such as b and i, a, and img.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:complexContent>
+						<xsd:extension base="requirementsType">
+							<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+							<xsd:attribute name="RELATEDMAT" type="xsd:IDREFS" use="optional"/>
+							<xsd:attribute name="EXAMPLES" type="xsd:IDREFS" use="optional"/>
+							<xsd:attribute name="REQLEVEL" use="optional">
+								<xsd:annotation>
+									<xsd:documentation xml:lang="en">The enumeration values for this element are drawn from RFC 2119 (http://www.ietf.org/rfc/rfc2119.txt).  The definitions provided below are drawn from that source</xsd:documentation>
+								</xsd:annotation>
+								<xsd:simpleType>
+									<xsd:restriction base="xsd:string">
+										<xsd:enumeration value="MUST">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">This word means that the definition is an absolute requirement.
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:enumeration>										
+										<xsd:enumeration value="SHOULD">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">This word means that there may exist valid reasons in particular circumstances to ignore the requirement, but the full implications must be understood and carefully weighed before choosing a different course.
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:enumeration>
+										<xsd:enumeration value="MUST NOT">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">This phrase means that the prohibition described in the requirement is an absolute prohibition of the profile.</xsd:documentation>
+											</xsd:annotation>
+										</xsd:enumeration>
+										<xsd:enumeration value="SHOULD NOT">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">This phrase means that there may exist valid reasons in particular circumstances when violating the prohibition described in the requirement is acceptable or even useful, but the full implications should be understood and the case carefully weighed before doing so. The requirement text should clarify such circumstances.
+												</xsd:documentation>
+											</xsd:annotation>
+										</xsd:enumeration>
+										<xsd:enumeration value="MAY">
+											<xsd:annotation>
+												<xsd:documentation xml:lang="en">This word means that an item is not prohibited but fully optional.</xsd:documentation>
+											</xsd:annotation>
+										</xsd:enumeration>
+									</xsd:restriction>
+								</xsd:simpleType>
+							</xsd:attribute>
+						</xsd:extension>
+					</xsd:complexContent>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	
+	<!-- only the following group of HTML elements are allowed:
+		Paragraphs: <p>
+		All list elements: <ul>,<ol>,<dl>
+		Preformatted text: <pre>
+		Table: <table>
+		Image: <img>
+	-->
+	<xsd:group name="xhtmlelements">
+		<xsd:choice>
+			<xsd:element ref="xhtml:p"/>
+			<xsd:group ref="xhtml:lists"/>
+		</xsd:choice>	
+	</xsd:group>
+	
+	
+	<xsd:complexType name="pType" mixed="true">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:group ref="xhtmlelements"/>								
+		</xsd:choice>
+	</xsd:complexType>	
+	
+	<xsd:complexType name="requirementsType">
+		<xsd:sequence>
+			<xsd:element name="description" type="textSection" minOccurs="1"/>
+			<xsd:element name="tests" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation xml:lang="en">The optional tests subelement of description exists to supplement a textual description of a requirement with one that can be used to eventually provide machine validation. It includes one or more testGrp elements, which in turn contain testWrap or testRep elements. It is assumed each test’s desired outcome is to evaluate to &quot;true.&quot; Implementers must ensure that the requirement level indicated and any formal test evaluation pattern are aligned so that the test indicates conformance rather than an error.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="test" minOccurs="1" maxOccurs="unbounded">
+							<xsd:annotation>
+								<xsd:documentation xml:lang="en">The test element contains the following attributes:
+1.	ID: an optional attribute uniquely identifying this element within the METS Profile document
+2.	LABEL: an optional textual description of the test being performed
+3.	TESTLANGUAGE: a required attribute indicating the language in which the test is expressed, such as XPath or XQuery
+4.	TESTLANGUAGEVERSION: an optional attribute indicating what version of the testing language has been used
+5.	TESTLANGUAGEURI: an optional attribute indicating an authoritative URI for the testing language used</xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="testString">
+										<xsd:complexType>
+											<xsd:simpleContent>
+												<xsd:extension base="xsd:string">
+													<xsd:attribute name="CONTEXT" type="xsd:string" use="optional"/>
+													<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+												</xsd:extension>
+											</xsd:simpleContent>													
+										</xsd:complexType>										
+									</xsd:element>
+									<xsd:element name="testWrap">
+										<xsd:annotation>
+											<xsd:documentation xml:lang="en">The testWrap element has a test subelement with an optional CONTEXT attribute used to indicate the context in which a test should be evaluated. The value of the text element should be the actual text expression in the selected testing language.</xsd:documentation>
+										</xsd:annotation>
+										<xsd:complexType>
+											<xsd:choice>													
+												<xsd:element name="testBin">
+													<xsd:annotation>
+														<xsd:documentation xml:lang="en">
+															A binary data wrapper element &lt;binData&gt; is used to contain a Base64 encoded file.
+														</xsd:documentation>
+													</xsd:annotation>
+													<xsd:complexType>
+														<xsd:simpleContent>
+															<xsd:extension base="xsd:base64Binary">
+																<xsd:attribute name="CONTEXT" type="xsd:string" use="optional"/>
+																<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+															</xsd:extension>
+														</xsd:simpleContent>															
+													</xsd:complexType>
+												</xsd:element>
+												<xsd:element name="testXML">
+													<xsd:annotation>
+														<xsd:documentation xml:lang="en">
+															An xml data wrapper element &lt;xmlData&gt; is used to contain  an XML encoded file. The content of an &lt;xmlData&gt; element can be in any namespace or in no namespace. As permitted by the XML Schema Standard, the processContents attribute value for the metadata in an &lt;xmlData&gt; element is set to “lax”. Therefore, if the source schema and its location are identified by means of an xsi:schemaLocation attribute, then an XML processor will validate the elements for which it can find declarations. If a source schema is not identified, or cannot be found at the specified schemaLocation, then an XML validator will check for well-formedness, but otherwise skip over the elements appearing in the &lt;xmlData&gt; element.
+														</xsd:documentation>
+													</xsd:annotation>
+													<xsd:complexType>
+														<xsd:sequence>
+															<xsd:any namespace="##any" maxOccurs="unbounded" processContents="lax"/>
+														</xsd:sequence>
+														<xsd:attribute name="CONTEXT" type="xsd:string" use="optional"/>
+														<xsd:attribute name="ID" type="xsd:ID" use="optional"/>										
+													</xsd:complexType>
+												</xsd:element>											
+											</xsd:choice>
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+										</xsd:complexType>							
+									</xsd:element>
+									<xsd:element name="testRef">
+										<xsd:annotation>
+											<xsd:documentation xml:lang="en">The testRef element is intended to point to testing code stored elsewhere. It contains a LOCREF attribute to point to this testing code. When using testing code not easily embedded inside the METS Profile, such as that written in Perl, testRef is preferred over testWrap.</xsd:documentation>
+										</xsd:annotation>
+										<xsd:complexType>
+											<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+											<xsd:attribute name="LOCREF" type="xsd:string" use="required"/>
+											<xsd:attribute name="LOCTYPE" type="xsd:string" use="required"/>										
+										</xsd:complexType>
+									</xsd:element>
+								</xsd:choice>
+								<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+								<xsd:attribute name="LABEL" type="xsd:string" use="optional"/>
+								<xsd:attribute name="TESTLANGUAGE" type="xsd:string" use="required"/>
+								<xsd:attribute name="TESTLANGUAGEVERSION" type="xsd:string"/>
+								<xsd:attribute name="TESTLANGUAGEURI" type="xsd:anyURI"/>									
+							</xsd:complexType>							
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="ID" type="xsd:ID" use="optional"/>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>	
+	</xsd:complexType>
+	
+	<xsd:simpleType name="medString">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="256"/>
+			<xsd:minLength value="1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="longString">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
This updates the METS profile schema to be used with [METS version 2](https://github.com/mets/METS-schema/blob/mets2/v2/mets.xsd)

## Summary of changes

  Changes to align with linking and external references in METS 2:
  * allows any values for LOCTYPE
  * removes the OTHERLOCTYPE attribute.
  * removes the XLink schema and the xlink attributes for the testRef element
  * adds LOCREF and LOCTYPE attributes for the testRef element
  
  Changes to align with METS 2 elements:
  * replaces amdSec, dmdSec elements with mdSec
  * replaces structMap element with structSec,
  * removes structLink and behaviorSec elements
  * removes behavior_files element

## Still TODO

* In-line documentation for changed elements and attributes
* Convert version history comments to `<xsd:annotation>/<xsd:documentation>` as in https://github.com/mets/METS-schema/commit/db5d582e92f08edf5fcde7b0ff5f2af3571496bd
* Update other documentation for METS profile schema